### PR TITLE
Fix async in GetSentencesMeaning

### DIFF
--- a/Services/OpenAIService.cs
+++ b/Services/OpenAIService.cs
@@ -31,7 +31,8 @@ namespace SentenceMining.Services
             {
                 using StreamReader fileReader = new(file.OpenReadStream());
                 ChatClient client = new(model: "gpt-4o-mini", apiKey: Environment.GetEnvironmentVariable("OPENAI_API_KEY"));
-                ChatCompletion completion = client.CompleteChat($"{Prompt}{await fileReader.ReadToEndAsync()}");
+                var fileContent = await fileReader.ReadToEndAsync();
+                ChatCompletion completion = await client.CompleteChatAsync($"{Prompt}{fileContent}");
 
                 return completion.Content[0].Text;
             }


### PR DESCRIPTION
## Summary
- switch GetSentencesMeaning to use `CompleteChatAsync`

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d51b3c28832c83f2f250e7073b38